### PR TITLE
bump linux-lts to 4.9.42

### DIFF
--- a/linux-lts/PKGBUILD
+++ b/linux-lts/PKGBUILD
@@ -4,8 +4,8 @@
 pkgbase=linux-lts
 #pkgbase=linux-lts-custom
 _srcname=linux-4.9
-pkgver=4.9.40
-pkgrel=2
+pkgver=4.9.42
+pkgrel=1
 arch=('i686' 'x86_64')
 url="https://www.kernel.org/"
 license=('GPL2')
@@ -23,7 +23,7 @@ source=(https://www.kernel.org/pub/linux/kernel/v4.x/${_srcname}.tar.{xz,sign}
 # https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 sha256sums=('029098dcffab74875e086ae970e3828456838da6e0ba22ce3f64ef764f3d7f1a'
             'SKIP'
-            '8e85a7e9de8fcc2f06f8539b743de30e2ba1f5b9e6784da0701c3ab2b896f019'
+            '9815eac9c8acc4751ff0c2232106c455ce336779f282db160cdd65d87d82b18e'
             'SKIP'
             '39e780d61a46eae6ff7714b070942c7c033d449436df561727a93c64d28b3485'
             '50193426ac5d777475336df0ff5350c7de933f2ea2641fbe8956387c75b4c100'


### PR DESCRIPTION
Artix package out-of-date with Arch (causes version conflict on kernel module packages like acpi_call-lts).