### PR TITLE
Bump linux-lts to 4.9.45-1

### DIFF
--- a/linux-lts/PKGBUILD
+++ b/linux-lts/PKGBUILD
@@ -4,7 +4,7 @@
 pkgbase=linux-lts
 #pkgbase=linux-lts-custom
 _srcname=linux-4.9
-pkgver=4.9.44
+pkgver=4.9.45
 pkgrel=1
 arch=('i686' 'x86_64')
 url="https://www.kernel.org/"
@@ -23,7 +23,7 @@ source=(https://www.kernel.org/pub/linux/kernel/v4.x/${_srcname}.tar.{xz,sign}
 # https://www.kernel.org/pub/linux/kernel/v4.x/sha256sums.asc
 sha256sums=('029098dcffab74875e086ae970e3828456838da6e0ba22ce3f64ef764f3d7f1a'
             'SKIP'
-            'cd9ce14bda09cfba792b29c38b80396ab9e2adcbc5b71795497cd3775985efaa'
+            '3af913e439dad8655e6212971914e5ab8923de693077614ace1777d683d911c5'
             'SKIP'
             '39e780d61a46eae6ff7714b070942c7c033d449436df561727a93c64d28b3485'
             '50193426ac5d777475336df0ff5350c7de933f2ea2641fbe8956387c75b4c100'


### PR DESCRIPTION
This pull request will bump linux-lts to 4.9.45 to reflect the changes [on the arch linux ](https://git.archlinux.org/svntogit/packages.git/commit/trunk/PKGBUILD?h=packages/linux-lts&id=659d714ddf1039f39e717af149c97fa8554c363f) and also to prevent pacman update error on some users ( Please see http://elkarte.cyber-labs.de/index.php/topic,6.0.html )

Thanks! Appreciated it!