### PR TITLE
Restore locate cron file, remove systemd specifics

### DIFF
--- a/mlocate/PKGBUILD
+++ b/mlocate/PKGBUILD
@@ -18,14 +18,10 @@ _commit=596d4ad222328e8bae7a00cc489a9f862edc82fb #tag=upstream/0.26
 source=("git+https://anonscm.debian.org/cgit/collab-maint/mlocate.git#commit=$_commit"
 	'sysusers.d'
 	'updatedb.conf'
-	'updatedb.timer'
-	'updatedb.service'
 	'updatedb.cron')
 sha256sums=('SKIP'
             '1713a8fc8b81f4a390bf8597c4c0e917474379002dcc984aad2f44218d10c82a'
             'ea65bb68bb854803965ac16c770ba2567256e2066d68c272f1a1974ffc5c5ee7'
-            '2e813effb651fae101d93722827553c6b9b9d42e898e808db4991eafdd330e02'
-            '83c7a508bad5dccd55a158cf8b8029d680f82cf8b1d21074279def14d9ad4dee'
             '9f0c18a683f0dbeeae3f673bc3b2dbe1b54173da1589598672f254eb7a708f1e')
 
 prepare() {

--- a/mlocate/PKGBUILD
+++ b/mlocate/PKGBUILD
@@ -5,12 +5,13 @@
 
 pkgname=mlocate
 pkgver=0.26
-pkgrel=6
+pkgrel=7
 pkgdesc='Merging locate/updatedb implementation'
 url='https://anonscm.debian.org/cgit/collab-maint/mlocate.git'
 arch=('i686' 'x86_64')
 license=('GPL')
-backup=('etc/updatedb.conf')
+backup=('etc/updatedb.conf'
+        'etc/cron.daily/updatedb')
 depends=('glibc')
 makedepends=('git')
 _commit=596d4ad222328e8bae7a00cc489a9f862edc82fb #tag=upstream/0.26
@@ -18,12 +19,14 @@ source=("git+https://anonscm.debian.org/cgit/collab-maint/mlocate.git#commit=$_c
 	'sysusers.d'
 	'updatedb.conf'
 	'updatedb.timer'
-	'updatedb.service')
+	'updatedb.service'
+	'updatedb.cron')
 sha256sums=('SKIP'
             '1713a8fc8b81f4a390bf8597c4c0e917474379002dcc984aad2f44218d10c82a'
             'ea65bb68bb854803965ac16c770ba2567256e2066d68c272f1a1974ffc5c5ee7'
             '2e813effb651fae101d93722827553c6b9b9d42e898e808db4991eafdd330e02'
-            '83c7a508bad5dccd55a158cf8b8029d680f82cf8b1d21074279def14d9ad4dee')
+            '83c7a508bad5dccd55a158cf8b8029d680f82cf8b1d21074279def14d9ad4dee'
+            '9f0c18a683f0dbeeae3f673bc3b2dbe1b54173da1589598672f254eb7a708f1e')
 
 prepare() {
 	cd "${srcdir}/${pkgname}"
@@ -54,5 +57,6 @@ package() {
 	install -dm750 -g21 "${pkgdir}/var/lib/locate"
 
 	install -Dm644 ../updatedb.conf "${pkgdir}/etc/updatedb.conf"
+	install -Dm744 ../updatedb.cron "${pkgdir}/etc/cron.daily/updatedb"
 	install -Dm644 ../sysusers.d "${pkgdir}/usr/lib/sysusers.d/locate.conf"
 }

--- a/mlocate/updatedb.cron
+++ b/mlocate/updatedb.cron
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+NICE='nice -n 19'
+IONICE='ionice -c 2 -n 7'
+
+exec ${IONICE} ${NICE} updatedb -f proc

--- a/mlocate/updatedb.service
+++ b/mlocate/updatedb.service
@@ -1,7 +1,0 @@
-[Unit]
-Description=Update locate database
-
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/updatedb
-IOSchedulingClass=idle

--- a/mlocate/updatedb.timer
+++ b/mlocate/updatedb.timer
@@ -1,7 +1,0 @@
-[Unit]
-Description=Daily locate database update
-
-[Timer]
-OnCalendar=daily
-AccuracySec=12h
-Persistent=true


### PR DESCRIPTION
PR to restore Arch's last crontab file for mlocate prior to systemd assimilation.

Also removed systemd service and timer files.

Anyone care to comment if I can also remove the /usr/lib/sysusers.d/ related file(s)? I assume so unless there are plans to parse them at some point. Happy to update the PR to remove said file(s).